### PR TITLE
Initial Migration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   # Repos can be uppercase but tags can't, so hardcode where needed
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: anti-computer-club/flipmap-caddy
 
 jobs:
   build-and-push-caddy:
@@ -92,5 +92,5 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /srv/
-            docker-compose up -d --pull always
+            docker compose up -d --pull always
             docker image prune

--- a/Caddy/Dockerfile
+++ b/Caddy/Dockerfile
@@ -1,8 +1,8 @@
-# builds Caddy, which provides easy TLS & rate-limiting
+# builds Caddy, which provides easy TLS
 FROM caddy:2.9.1-builder AS builder
 
-RUN xcaddy build \
-  --with github.com/mholt/caddy-ratelimit
+RUN xcaddy build 
+#--with github.com/mholt/caddy-ratelimit maybe another time
 
 FROM caddy:2.9.1
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,4 @@
+name: flipmap
 services:
   backend:
     image: ghcr.io/anti-computer-club/flipmap-backend:latest
@@ -25,6 +26,7 @@ services:
       - "127.0.0.1:2019:2019"
     volumes:
       - caddy_data:/data
+      - /srv/www:/srv/www:ro
 
 volumes:
   # 'Not a Cache' purging will remove certs, OCSP staples, etc


### PR DESCRIPTION
This repo builds and pushes caddy with a single combined caddy file (in repo), and then updates the compose file and recreates (including pulling) all containers

The backend builds, pushes, and recreates just itself.

Neither are downtime free and we even delete the compose here regardless of whether it was updated

Needs https://github.com/anti-computer-club/flipmap-backend/pull/28 first to create the initial backend container in the org